### PR TITLE
[cargo] Updated the version to 0.11.0-rc.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Test
-        run: cargo test --verbose
+        run: cargo test --verbose -- --nocapture
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clerr"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 description = "This library aids in command-line error reporting."
 keywords = ["cli", "error", "report", "log", "terminal"]
 categories = ["command-line-interface", "development-tools::debugging"]

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,12 +1,19 @@
 # Issues
 
-## 1. Allocation Performance
+## Allocation Performance
 
 The `colored` crate's `ColoredString` type owns its string data. When building reports, this can lead to many small
-allocations. This is unlikely to be a real performance issue since info & error reports should not be super common.
-There seem to be optimizations that can be made within the crate to reduce allocations as well.
+allocations. This is unlikely to be a real performance issue since info & error reports should not be present in any
+high performance code. There are optimizations that can be made but this would come at a high cost of usability.
 
-## 2. Testing
+## Testing
 
-The crate lacks assertion-based tests. The existing tests only use `println!` for manual inspection and cannot catch
-regressions in output formatting. Tests should strip ANSI escape codes and assert on the plain-text output.
+The crate lacks assertion-based tests. The existing tests only use `println!` for manual inspection and cannot
+automatically catch regressions in output formatting. Automated regression testing is preferred, but it is not only
+difficult to test visuals but there is also issues with `ColoredString` comparison on different platforms.
+
+## TokenInfo Alignment
+
+`TokenInfo` rendering uses `position` and `token_len` to generate spaces and carets for alignment. This assumes each
+character in `line_text` occupies exactly one display column, which breaks for multibyte UTF-8 characters, wide
+characters (CJK), and tabs.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This library aids in command-line error reporting.
 
-    clerr = "0.10.0"
+    clerr = "0.11.0-rc.1"
 
 ## Examples
 
@@ -81,14 +81,14 @@ error[E042]: invalid encoding
 
 Three severity levels are available, each with a distinct color:
 
-| Level     | Color  |
-|-----------|--------|
-| `Error`   | Red    |
-| `Warning` | Yellow |
-| `Info`    | Blue   |
+| Level     | Color        |
+|-----------|--------------|
+| `Error`   | BrightRed    |
+| `Warning` | BrightYellow |
+| `Info`    | BrightBlue   |
 
-These colors are intentionally fixed for consistency.
+These colors are intentionally fixed for consistency and consideration for the colorblind.
 
 ## Issues & Contributing
 
-See [ISSUES.md](ISSUES.md) for future work and [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [ISSUES.md](ISSUES.md) for issues & future work and [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/report/entry.rs
+++ b/src/report/entry.rs
@@ -3,10 +3,11 @@ use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
-/// A report entry that wraps `Vec<ColoredString>` and ignores color on comparison operations.
+/// A report entry that wraps [Vec<ColoredString>] and ignores color on comparison operations.
 #[derive(Clone, Debug)]
+#[repr(transparent)]
 pub struct Entry {
-    strings: Vec<ColoredString>,
+    pub strings: Vec<ColoredString>,
 }
 
 impl From<Vec<ColoredString>> for Entry {
@@ -18,15 +19,6 @@ impl From<Vec<ColoredString>> for Entry {
 impl From<Entry> for Vec<ColoredString> {
     fn from(entry: Entry) -> Self {
         entry.strings
-    }
-}
-
-impl Entry {
-    //! Properties
-
-    /// Gets the colored strings.
-    pub fn strings(&self) -> &[ColoredString] {
-        self.strings.as_slice()
     }
 }
 
@@ -47,8 +39,8 @@ impl Ord for Entry {
     fn cmp(&self, other: &Self) -> Ordering {
         self.strings
             .iter()
-            .map(|f| f.as_bytes())
-            .cmp(other.strings.iter().map(|f| f.as_bytes()))
+            .map(|fragment| fragment.as_bytes())
+            .cmp(other.strings.iter().map(|fragment| fragment.as_bytes()))
     }
 }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,11 +1,10 @@
-pub use entry::*;
 pub use properties::*;
 pub use report::*;
 pub use token_info::*;
 
-mod entry;
 mod properties;
 mod report;
 mod token_info;
 
+pub(crate) mod entry;
 pub(crate) mod util;

--- a/src/report/properties.rs
+++ b/src/report/properties.rs
@@ -46,25 +46,25 @@ impl Properties {
     }
 }
 
-impl From<Properties> for Vec<ColoredString> {
-    fn from(props: Properties) -> Vec<ColoredString> {
-        let max_len: usize = props
-            .properties
+impl From<&Properties> for Vec<ColoredString> {
+    fn from(properties: &Properties) -> Vec<ColoredString> {
+        let properties: &[(String, String)] = properties.properties.as_slice();
+        let max_len: usize = properties
             .iter()
-            .map(|(p, _)| p.len())
+            .map(|(name, _)| name.len())
             .max()
             .unwrap_or(0);
-        let len: usize = props.properties.len();
+        let count: usize = properties.len();
         let color: Color = Info.color();
-        let mut result: Vec<ColoredString> = Vec::new();
-        for (i, (property, value)) in props.properties.into_iter().enumerate() {
-            let spaces: String = util::char_count(' ', max_len - property.len() + 2);
+        let max_spaces: String = util::char_count(' ', max_len + 2);
+        let mut result: Vec<ColoredString> = Vec::with_capacity(count * 6);
+        for (i, (property, value)) in properties.iter().enumerate() {
             result.push("    ".normal());
             result.push(property.color(color));
             result.push(":".color(color));
-            result.push(spaces.normal());
-            result.push(value.normal());
-            if i + 1 < len {
+            result.push(max_spaces[..(max_len - property.len() + 2)].normal());
+            result.push(value.as_str().normal());
+            if i + 1 < count {
                 result.push("\n".normal());
             }
         }
@@ -72,9 +72,15 @@ impl From<Properties> for Vec<ColoredString> {
     }
 }
 
+impl From<Properties> for Vec<ColoredString> {
+    fn from(props: Properties) -> Vec<ColoredString> {
+        Vec::from(&props)
+    }
+}
+
 impl Display for Properties {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let strings: Vec<ColoredString> = Vec::from(self.clone());
+        let strings: Vec<ColoredString> = Vec::from(self);
         for string in &strings {
             write!(f, "{}", string)?;
         }

--- a/src/report/report.rs
+++ b/src/report/report.rs
@@ -35,8 +35,8 @@ impl Report {
     }
 
     /// Gets the entries.
-    pub fn entries(&self) -> &[Entry] {
-        self.entries.as_slice()
+    pub fn entries(&self) -> &[Vec<ColoredString>] {
+        unsafe { std::mem::transmute(self.entries.as_slice()) }
     }
 }
 
@@ -48,10 +48,7 @@ impl Report {
     where
         E: Into<Vec<ColoredString>>,
     {
-        let entry: Vec<ColoredString> = entry.into();
-        if !entry.is_empty() {
-            self.entries.push(Entry::from(entry));
-        }
+        self.entries.push(Entry::from(entry.into()));
     }
 
     /// Adds the `entry`.

--- a/src/report/token_info.rs
+++ b/src/report/token_info.rs
@@ -20,9 +20,9 @@ pub struct TokenInfo<'a> {
     pub severity: Severity,
     /// The file name.
     pub file_name: &'a str,
-    /// The 1-based line number.
+    /// The 1-indexed line number.
     pub line: usize,
-    /// The 0-based column position within the line.
+    /// The 0-indexed column position within the line.
     pub position: usize,
     /// The text content of the line.
     pub line_text: &'a str,
@@ -36,17 +36,18 @@ impl<'a> From<TokenInfo<'a>> for Vec<ColoredString> {
     fn from(info: TokenInfo<'a>) -> Vec<ColoredString> {
         let line_number: String = info.line.to_string();
         let spaces: String = util::char_count(' ', line_number.len());
+        let ln_spaces: ColoredString = format!("\n{spaces}").normal();
         let color: Color = info.severity.color();
         let indent: String = util::char_count(' ', info.position);
         let carets: String = util::char_count('^', info.token_len);
 
         vec![
             // 1 - file name
-            spaces.clone().normal(),
+            spaces.as_str().normal(),
             "-->".bright_blue(),
             util::file_and_token(info.file_name, info.line, info.position).normal(),
             // 2 - empty
-            format!("\n{spaces}").normal(),
+            ln_spaces.clone(),
             " | ".bright_blue(),
             // 3 - line text
             "\n".normal(),
@@ -54,14 +55,14 @@ impl<'a> From<TokenInfo<'a>> for Vec<ColoredString> {
             " | ".bright_blue(),
             info.line_text.normal(),
             // 4 - error message
-            format!("\n{spaces}").normal(),
+            ln_spaces.clone(),
             " | ".bright_blue(),
             indent.normal(),
             carets.color(color),
             " --- ".color(color),
             info.message.color(color),
             // 5 - empty
-            format!("\n{spaces}").normal(),
+            ln_spaces,
             " | ".bright_blue(),
         ]
     }

--- a/src/severity.rs
+++ b/src/severity.rs
@@ -13,7 +13,7 @@ impl Severity {
     //! Display
 
     /// Gets the label string.
-    pub(crate) fn label(self) -> &'static str {
+    pub fn label(self) -> &'static str {
         match self {
             Self::Error => "error",
             Self::Warning => "warning",
@@ -22,7 +22,7 @@ impl Severity {
     }
 
     /// Gets the associated color.
-    pub(crate) fn color(self) -> Color {
+    pub fn color(self) -> Color {
         match self {
             Self::Error => Color::BrightRed,
             Self::Warning => Color::BrightYellow,


### PR DESCRIPTION
  - Made Entry an internal type, hiding it from the public API using #[repr(transparent)] and transmute.
  - Made Severity::label() and Severity::color() public.
  - Removed unnecessary clone in Properties Display impl by implementing From<&Properties>.
  - Reduced allocations in Properties and TokenInfo rendering.
  - Removed silent dropping of empty entries in Report::add_entry.
  - Added --nocapture to CI test step.
  - Added TokenInfo alignment issue to ISSUES.md.
  - Updated README severity colors to match actual values.